### PR TITLE
Keep diffbox visible despite long test names

### DIFF
--- a/public/static/dist/css/styles.css
+++ b/public/static/dist/css/styles.css
@@ -1193,6 +1193,9 @@ ul.tooltip-tasks li.tooltip-task {
   overflow-y: auto;
   overflow-x: none;
 }
+.patch-diff-panel tbody {
+  word-break: break-word;
+}
 .patch-diff-panel tr .extra-info {
   font-size: 10px;
   color: #777;


### PR DESCRIPTION
When a test with a long name appears in this table, it prevents text wrapping in its table cell, which makes the table too wide for its scrolling container. Because the container has overflow-x: none, you can't scroll to see the red/green diffboxes.

![Screen Shot 2019-11-08 at 11 15 05 AM](https://user-images.githubusercontent.com/349909/68493418-7004f600-021a-11ea-858e-00d6b2e27b46.png)


The fix is to allow text wrapping to break in the middle of a word. This prevents the text from forcing the table to be wider than its container.

![Screen Shot 2019-11-08 at 11 14 50 AM](https://user-images.githubusercontent.com/349909/68493424-73987d00-021a-11ea-9ce3-d063647d05af.png)
